### PR TITLE
v0.1.2: Support ping gif on less secretive url (ping_ap_mode.gif)

### DIFF
--- a/octoprint_findmymrbeam/__init__.py
+++ b/octoprint_findmymrbeam/__init__.py
@@ -27,6 +27,7 @@ class FindMyMrBeamPlugin(octoprint.plugin.StartupPlugin,
 		import string
 		chars = string.ascii_lowercase + string.ascii_uppercase + string.digits
 		self._secret = "".join(choice(chars) for _ in range(32))
+		self._not_so_secret = "ping_ap_mode"
 
 	def initialize(self):
 		self._url = self._settings.get(["url"])
@@ -63,7 +64,7 @@ class FindMyMrBeamPlugin(octoprint.plugin.StartupPlugin,
 	@octoprint.plugin.BlueprintPlugin.route("/<secret>.gif", methods=["GET"])
 	def is_online_gif(self, secret):
 
-		if self._secret != secret:
+		if secret not in (self._secret, self._not_so_secret):
 			flask.abort(404)
 
 		# send a transparent 1x1 px gif

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_findmymrbeam"
 plugin_name = "OctoPrint-FindMyMrBeam"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.1"
+plugin_version = "0.1.2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
This is required since MrBeamPlugin 0.1.30 where we ping this gif
if our webinterface seems to run on domain find.mr-beam. org.
In this case we redirect.