### PR TITLE
SW-2270-change-registry-url-to-alpha-url-of-mr-beam-cloud

### DIFF
--- a/octoprint_findmymrbeam/__init__.py
+++ b/octoprint_findmymrbeam/__init__.py
@@ -186,7 +186,9 @@ class FindMyMrBeamPlugin(octoprint.plugin.AssetPlugin,
 
 	def get_settings_defaults(self):
 		return dict(enabled=True,
-					url="https://find.mr-beam.org/registry",
+					# url="https://find.mr-beam.org/registry",
+					# Revert this change before beta release
+					url="https://alpha-dot-find-mr-beam.appspot.com/registry",
 					interval_client=300.0,
 					interval_noclient=60.0,
 					# configured in config.yaml in appearance:{name: aBook}

--- a/octoprint_findmymrbeam/__init__.py
+++ b/octoprint_findmymrbeam/__init__.py
@@ -186,8 +186,9 @@ class FindMyMrBeamPlugin(octoprint.plugin.AssetPlugin,
 
 	def get_settings_defaults(self):
 		return dict(enabled=True,
+					# Revert this change before beta release(https://mr-beam.atlassian.net/browse/SW-2272)
+					# in https://mr-beam.atlassian.net/browse/SW-2273
 					# url="https://find.mr-beam.org/registry",
-					# Revert this change before beta release
 					url="https://alpha-dot-find-mr-beam.appspot.com/registry",
 					interval_client=300.0,
 					interval_noclient=60.0,


### PR DESCRIPTION
Changed the find mr beam registry link to the alpha cloud instance